### PR TITLE
Add a patch for gtk-sharp3

### DIFF
--- a/gtk-sharp-profiler-startup.patch
+++ b/gtk-sharp-profiler-startup.patch
@@ -1,0 +1,11 @@
+diff -Naur gtk-sharp.org/gtk/gui-thread-check/profiler/gui-thread-check.c gtk-sharp/gtk/gui-thread-check/profiler/gui-thread-check.c
+--- gtk-sharp.org/gtk/gui-thread-check/profiler/gui-thread-check.c	2018-12-07 05:05:42.325500894 +0100
++++ gtk-sharp/gtk/gui-thread-check/profiler/gui-thread-check.c	2018-12-07 05:40:53.044438289 +0100
+@@ -93,6 +93,6 @@
+ 	
+ 	mono_profiler_install (NULL, NULL);
+ 	mono_profiler_install_enter_leave (simple_method_enter, NULL);
+-	mono_profiler_set_events (MONO_PROFILE_ENTER_LEAVE);
++	mono_profiler_set_events (1 << 12);
+ }
+ 

--- a/org.gnome.gbrainy.json
+++ b/org.gnome.gbrainy.json
@@ -35,6 +35,10 @@
                     "type": "git",
                     "url": "https://github.com/mono/gtk-sharp.git",
                     "commit": "9ef7d3f394b9d485674c59e92db24ac66fd9f16b"
+                },
+                {
+                    "type": "patch",
+                    "path": "gtk-sharp-profiler-startup.patch"
                 }
             ]
         },


### PR DESCRIPTION
Due to the [upgrade](https://github.com/flathub/org.freedesktop.Sdk.Extension.mono5/commit/6f0341cb183e6b1d75289116b1e930190876a1d7) of Mono from 5.4 to 5.16, the current package can not be built.

```
gui-thread-check.c:96:28: error: ‘MONO_PROFILE_ENTER_LEAVE’ undeclared (first use in this function)
  mono_profiler_set_events (MONO_PROFILE_ENTER_LEAVE);
```

This is a [patch](https://github.com/scx/org.gnome.gbrainy/blob/ed2883a89cfd996c8e1e2a83ff23586c8971a0b6/gtk-sharp-profiler-startup.patch) for it.
See also: https://github.com/mono/mono/commit/ea4e4a9ef6fc42570a23026adbe826cf7248290e

